### PR TITLE
fix [Error] EK0004 issue

### DIFF
--- a/src/compiler/util.c
+++ b/src/compiler/util.c
@@ -124,7 +124,11 @@ Char* GetDir(const Char* path, Bool dir, const Char* add_name)
 		while (ptr != path && *ptr != L'\\' && *ptr != L'/')
 			ptr--;
 		if (ptr == path)
-			return L"./";
+		{
+			result = (Char*)Alloc(sizeof(Char) * (2 + len_add_name + 1));
+			wcscpy(result, L"./");
+		}
+		else
 		{
 			size_t len2 = ptr - path + 1;
 			size_t i;


### PR DESCRIPTION
カレントディレクトリ直下のソースコードのコンパイル時に、
【kuincl.exe -e cui -i foo.kn】と言う具合に、
「【-i .\foo.kn】ではなく、【-i foo.kn】」かつ「-oを省略」という条件で、
【 [Error] EK0004: 出力ファイル「./」の書き込みに失敗しました。】
となるのを修正しました。