### PR TITLE
add \0

### DIFF
--- a/src/compiler/parse.c
+++ b/src/compiler/parse.c
@@ -702,6 +702,7 @@ static Char EscChar(Char c)
 		case L'"': return L'"';
 		case L'\'': return L'\'';
 		case L'\\': return L'\\';
+		case L'0': return L'\0';
 		case L'n': return L'\n';
 		case L't': return L'\t';
 		case L'w': return L'\u3000';


### PR DESCRIPTION
【[Error] EP0007:
不正な形式のエスケープシーケンス「\0」が記述されました。】というコンパイルエラーが発生しましたが、仕様( http://kuina.ch/kuin/a2 )によると'\0'は有効ということになので、'\0'を追加しました。