### PR TITLE
fix 複数行コメントを空白1文字と見なすように修正 

### DIFF
--- a/src/compiler/parse.c
+++ b/src/compiler/parse.c
@@ -339,7 +339,7 @@ static Char Read(void)
 				continue;
 			case L'{':
 				ReadComment();
-				continue;
+				return L' ';
 			case L'\r':
 				continue;
 			case L'\t':


### PR DESCRIPTION
複数行コメント「{...}」の動作を、仕様( http://kuina.ch/kuin/a10 )に書かれている下記の記述に合わせました。
【「{」と「}」で囲んだ部分はコンパイル時に空白1文字と見なす。】