### PR TITLE
fix 単一行コメント「;」が機能しない場合があるのを修正しました。

### DIFF
--- a/src/compiler/parse.c
+++ b/src/compiler/parse.c
@@ -433,6 +433,7 @@ static Char ReadChar(void)
 						if (c == L'\0')
 							return L'\0';
 					} while (c != L'\n');
+					FileBuf = c;
 					return L'\n';
 				case L'|':
 					return ReadChar();
@@ -762,6 +763,21 @@ static SAstRoot* ParseRoot(void)
 		Char c = ReadChar();
 		if (c == L'\0')
 			break;
+		if (c == L';')
+		{
+			do
+			{
+				c = ReadBuf();
+				if (c == L'\u3000')
+				{
+					Err(L"EP0008", NewPos(SrcName, Row, Col));
+					continue;
+				}
+				if (c == L'\0')
+					return L'\0';
+			} while (c != L'\n');
+			continue;
+		}
 		if (c == L'\n')
 			continue;
 		{

--- a/test/correct/log0013.txt
+++ b/test/correct/log0013.txt
@@ -1,6 +1,7 @@
 Begin: ../../test/output/output0013.exe
 Excpt: 80000003
 > Line breaking.
+> Single line comment(;) vs. multi-line comment({}). pattern-1
 > 3, 1, 2, 3
 > 3, 2, 4
 > 3.14159
@@ -15,6 +16,7 @@ Excpt: 80000003
 > 
 > g
 > Line breaking.
+> Single line comment(;) vs. multi-line comment({}). pattern-1
 > 3, 1, 2, 3
 > 3, 2, 4
 > 3.14159
@@ -29,6 +31,7 @@ Excpt: 80000003
 > 
 > g
 > Line breaking.
+> Single line comment(;) vs. multi-line comment({}). pattern-1
 > 3, 1, 2, 3
 > 3, 2, 4
 > 3.14159

--- a/test/kn/test0013.kn
+++ b/test/kn/test0013.kn
@@ -1,7 +1,10 @@
+; Line comment 1.
+; Line comment 2.
 func main()
 	for(1, 3)
 		block
-			; Line comment.
+			; Line comment 3.
+			; Line comment 4.
 			{
 				{
 					Nest comment.
@@ -12,6 +15,14 @@ func main()
 			|(
 			|  "Line breaking."
 			|)
+
+			;{
+			do cui@print("Single line comment(;) vs. multi-line comment({}). pattern-1")
+			;}
+
+			{
+			do cui@print("Single line comment(;) vs. multi-line comment({}). pattern-2")
+			;}
 		end block
 
 		block


### PR DESCRIPTION
下記のコードのうち、「Line comment 3.」の行しかコメント扱いされずにコンパイルエラーとなっていたのを修正しました。
; Line comment 1.
; Line comment 2.
func main()
; Line comment 3.
; Line comment 4.
end func