### PR TITLE
コンパイル時の異常終了を修正

### DIFF
--- a/src/compiler/parse.c
+++ b/src/compiler/parse.c
@@ -1039,6 +1039,7 @@ static SAstVar* ParseVar(EAstArgKind kind, const Char* parent_class)
 	{
 		LocalErr = False;
 		ReadUntilRet();
+		return (SAstVar*)DummyPtr;
 	}
 	else
 		AssertNextChar(L'\n', True);
@@ -1054,6 +1055,7 @@ static SAstConst* ParseConst(void)
 	{
 		LocalErr = False;
 		ReadUntilRet();
+		return (SAstConst*)DummyPtr;
 	}
 	else
 		AssertNextChar(L'\n', True);


### PR DESCRIPTION
func main()
false
var x: int :: 1.
end func
というソースコード(コンパイルエラーになるソースコードです)のコンパイル時にkuincl.exeが異常終了するのを修正しました。
※追加した行はいずれも if (LocalErr)の中にありますが、ここでreturn
DummyPtr;をしてはいけない場合は、修正内容を下記のようにすると良いかもしれません。
ParseRoot関数内の、
((SAst*)((SAstVar*)child)->Var)->Public = child_public;
や
((SAst*)((SAstConst*)child)->Var)->Public = child_public;
が原因で異常終了するため、ParseRoot関数内の、
if (child == (SAst*)DummyPtr)
break;
でbraekする条件に((SAstVar*)child)->Var ==
(SAstArg*)DummyPtr)等を追加する、という修正内容です。