### PR TITLE
switchブロックのdefault節におけるコンパイルエラー時の異常終了を修正

### DIFF
--- a/src/compiler/parse.c
+++ b/src/compiler/parse.c
@@ -1663,6 +1663,8 @@ static SAstStat* ParseStatSwitch(int row, int col)
 			for (; ; )
 			{
 				stat = ParseStat((SAst*)ast);
+				if (stat == (SAstStat*)DummyPtr)
+					return (SAstStat*)DummyPtr;
 				type_id = ((SAst*)stat)->TypeId;
 				if (type_id == AstTypeId_StatEnd)
 					break;


### PR DESCRIPTION
default節で、ある種のコンパイルエラーになった場合(例えば、下記コードのコンパイル時)に
kuincl.exeが異常終了していたのを、修正しました。

func main()
var x: int
switch(x)
default
do x :: 1. {※コンパイルエラー「EP0017: 数値リテラルに不正な形式の「.」が記述されました。」になるコードです}
end switch
end func