### PR TITLE
Fix issue (コンパイル時の異常終了)

### DIFF
--- a/src/compiler/analyze.c
+++ b/src/compiler/analyze.c
@@ -3408,9 +3408,9 @@ static SAstExpr* RebuildExprValueArray(SAstExprValueArray* ast)
 		{
 			ptr->Data = RebuildExpr((SAstExpr*)ptr->Data, False);
 			{
-				SAstType* data_type = ((SAstExpr*)ptr->Data)->Type;
 				if (LocalErr)
 					return (SAstExpr*)DummyPtr;
+				SAstType* data_type = ((SAstExpr*)ptr->Data)->Type;
 				if (((SAstExpr*)ast)->Type == NULL)
 				{
 					if (((SAst*)data_type)->TypeId == AstTypeId_TypeNull)


### PR DESCRIPTION
下記コードのコンパイル時に kuincl.exeが異常終了していたのを修正しました。
func main()
var arr: []int :: [^0] {※コンパイルエラーになるコードです}
end func