### PR TITLE
Kuinエディタの保存動作を変更

### DIFF
--- a/src/kuin_editor/kuin_editor.kn
+++ b/src/kuin_editor/kuin_editor.kn
@@ -288,9 +288,6 @@ func chkChanged(): bool
 end func
 
 func save(new: bool): bool
-	if(!new & !@changed)
-		ret true
-	end if
 	var file: []char
 	if(new | @mainSrc = "_default_.kn")
 		do file :: wnd@saveFileDialog(@wndMain, ["Kuin source code (*.kn)", "*.kn"], 0, "kn")


### PR DESCRIPTION
@changedの値に依らず ファイルの保存を行うようにしました。
Kuinエディタ外でファイルが編集されたり削除されたりすることもあるため、このようにするのが良いと考えました。