### PR TITLE
「検索と置換」のチェックボックスの動作を修正

### DIFF
--- a/src/kuin_editor/kuin_editor.kn
+++ b/src/kuin_editor/kuin_editor.kn
@@ -2997,6 +2997,7 @@ func showFind(replace: bool)
 	do @wndFindEditReplace.enable(replace)
 	do @wndFindBtnReplace.enable(replace)
 	do @wndFindBtnReplaceAll.enable(replace)
+	do wndFindChkRegularExpressionOnPush(null)
 	do @wndFindEditPattern.focus()
 
 	; TODO:


### PR DESCRIPTION
「検索と置換」において。「正規表現を使用する」にチェックを入れた状態で一度「検索と置換」を閉じて、再度「検索と置換」を開いたときに、「大文字と小文字を区別する」と「単語単位」がグレーアウトされないのを修正しました。