### PR TITLE
【Kuinエディタ】存在しない行に行番号が表示される不具合の修正

### DIFF
--- a/src/kuin_editor/kuin_editor.kn
+++ b/src/kuin_editor/kuin_editor.kn
@@ -210,13 +210,10 @@ class DocumentSrc(@Document)
 		do draw@rect(0.0, 0.0, width $ float, height $ float, @colorBack)
 		var lineX: float :: (me.lineNumberWidth - 2) $ float
 		do draw@line(lineX, 0.0, lineX, height $ float, colorLineNumber)
-		for i(0, ^me.src.src - 1)
+		for i(0, ^me.src.src - 1 - me.pageY)
 			var y: float :: (i * @cellHeight) $ float
 			if(y < -@cellHeight $ float | y >= (height + @cellHeight) $ float)
 				skip i
-			end if
-			if(me.pageY + i + 1 > ^me.src.src)
-				break i
 			end if
 			var str: []char :: (me.pageY + i + 1).toStr()
 			do @font.draw((me.lineNumberWidth - (^str + 1) * @cellWidth + @cellWidth / 2) $ float, y, str, colorLineNumber)

--- a/src/kuin_editor/kuin_editor.kn
+++ b/src/kuin_editor/kuin_editor.kn
@@ -215,6 +215,9 @@ class DocumentSrc(@Document)
 			if(y < -@cellHeight $ float | y >= (height + @cellHeight) $ float)
 				skip i
 			end if
+			if(me.pageY + i + 1 > ^me.src.src)
+				break i
+			end if
 			var str: []char :: (me.pageY + i + 1).toStr()
 			do @font.draw((me.lineNumberWidth - (^str + 1) * @cellWidth + @cellWidth / 2) $ float, y, str, colorLineNumber)
 		end for


### PR DESCRIPTION
Kuinエディタでスクロールバーが出る程度の行数から、行を削除していったときに、存在しない行に行番号が残ってしまうのを修正しました。