### PR TITLE
【Kuinエディタ】行番号表示を常に3桁以上にしました。

### DIFF
--- a/src/kuin_editor/kuin_editor.kn
+++ b/src/kuin_editor/kuin_editor.kn
@@ -984,7 +984,7 @@ class DocumentSrc(@Document)
 		var scrWidth: int
 		var scrHeight: int
 		do @drawEditor.getPos(&, &, &scrWidth, &scrHeight)
-		do me.lineNumberWidth :: @cellWidth * (log10(^me.src.src) + 1)
+		do me.lineNumberWidth :: @cellWidth * (lib@max(log10(^me.src.src), 3) + 1)
 
 		if(me.cursorX < 0)
 			do me.cursorX :: lib@intMax


### PR DESCRIPTION
9行目や99行目で改行した際に行番号表示幅が増えることによって 全体的に右にシフトするのが気になってしまい コーディングに集中しにくいという問題があります。
このため、常に3桁は表示するようにしました。
好みによって変更できるのが良さそうですが、とりあえずの3桁です。

行番号表示時に3～5桁以上表示するエディタ/IDEが多い気がします。
・Vim: 3桁 (numberwidthのデフォルトが4。4-1=3桁が行番号に使用される。)
・Visual Studio 2017: 5桁