### PR TITLE
【Kuinエディタ】「end ブロック名」の自動入力のリファクタリング

### DIFF
--- a/src/kuin_editor/kuin_editor.kn
+++ b/src/kuin_editor/kuin_editor.kn
@@ -426,18 +426,17 @@ class DocumentSrc(@Document)
 						var y: int :: me.cursorY
 						do me.ins(x, y, "\n", true)
 						; The upper row.
-						var curIndent: int :: me.skipTabs(y)
-						if(curIndent = -1)
+						if(me.skipTabs(y) = -1)
 							do me.del(0, y, ^me.src.src[y], true)
 						else
+							do me.autoIndent(0, y)
 							if(^me.src.src[y + 1] = 0)
-								var result: [][]char :: @regexBlock.find(&, me.src.src[y], curIndent)
+								var result: [][]char :: @regexBlock.find(&, me.src.src[y], me.skipTabs(y))
 								if(result <>& null)
 									do me.ins(0, y + 1, "\nend " ~ result[1], true)
 									do me.autoIndent(0, y + 2)
 								end if
 							end if
-							do me.autoIndent(0, y)
 						end if
 						; The current row.
 						do me.autoIndent(0, y + 1)

--- a/src/kuin_editor/kuin_editor.kn
+++ b/src/kuin_editor/kuin_editor.kn
@@ -424,18 +424,19 @@ class DocumentSrc(@Document)
 					block
 						var x: int :: me.cursorX
 						var y: int :: me.cursorY
-						if(x = ^me.src.src[y])
-							var result: [][]char :: @regexBlock.find(&, me.src.src[y], me.skipTabs(y))
-							if(result <>& null)
-								do me.ins(x, y, "\nend " ~ result[1], true)
-								do me.autoIndent(x, y + 1)
-							end if
-						end if
 						do me.ins(x, y, "\n", true)
 						; The upper row.
-						if(me.skipTabs(y) = -1)
+						var curIndent: int :: me.skipTabs(y)
+						if(curIndent = -1)
 							do me.del(0, y, ^me.src.src[y], true)
 						else
+							if(^me.src.src[y + 1] = 0)
+								var result: [][]char :: @regexBlock.find(&, me.src.src[y], curIndent)
+								if(result <>& null)
+									do me.ins(0, y + 1, "\nend " ~ result[1], true)
+									do me.autoIndent(0, y + 2)
+								end if
+							end if
 							do me.autoIndent(0, y)
 						end if
 						; The current row.
@@ -1576,10 +1577,9 @@ class DocumentSrc(@Document)
 			do indent :: 0
 		end if
 		var replaceStr: []char :: "\t".repeat(indent) ~ (curIndent = -1 ?("", me.src.src[y].sub(curIndent, -1)))
-		do x :+ ^replaceStr - ^me.src.src[y]
 		do me.del(0, y, ^me.src.src[y], true)
 		do me.ins(0, y, replaceStr, true)
-		do me.cursorX :: x
+		do me.cursorX :: indent
 	end func
 
 	func skipTabs(y: int): int


### PR DESCRIPTION
「end ブロック名」の自動入力の最適化が甘かったのを修正しました。
また、改行時にカーソル位置より右側がタブ文字のみの場合の挙動(autoIndentメソッド内の処理)を修正しました。