### PR TITLE
【Kuinエディタ】単語補完リスト関連の不具合修正

### DIFF
--- a/src/kuin_editor/kuin_editor.kn
+++ b/src/kuin_editor/kuin_editor.kn
@@ -503,7 +503,7 @@ class DocumentSrc(@Document)
 			end if
 			ret true
 		case %up
-			if(@wndCompletion <>& null & @wndCompletionListKeywords <>& null)
+			if(shiftCtrl = %none & @wndCompletion <>& null & @wndCompletionListKeywords <>& null)
 				if(@wndCompletionListKeywords.len() <> 0)
 					var sel: int :: @wndCompletionListKeywords.getSel()
 					if(sel = -1)
@@ -534,7 +534,7 @@ class DocumentSrc(@Document)
 			end if
 			ret true
 		case %down
-			if(@wndCompletion <>& null & @wndCompletionListKeywords <>& null)
+			if(shiftCtrl = %none & @wndCompletion <>& null & @wndCompletionListKeywords <>& null)
 				var len: int :: @wndCompletionListKeywords.len()
 				if(len <> 0)
 					var sel: int :: @wndCompletionListKeywords.getSel()

--- a/src/kuin_editor/kuin_editor.kn
+++ b/src/kuin_editor/kuin_editor.kn
@@ -504,17 +504,16 @@ class DocumentSrc(@Document)
 			ret true
 		case %up
 			if(@wndCompletion <>& null & @wndCompletionListKeywords <>& null)
-				var sel: int :: @wndCompletionListKeywords.getSel()
-				if(sel = -1)
-					do sel :: @wndCompletionCursor
-				else
-					do sel :- 1
-					if(sel < 0)
-						do sel :: 0
+				if(@wndCompletionListKeywords.len() <> 0)
+					var sel: int :: @wndCompletionListKeywords.getSel()
+					if(sel = -1)
+						do sel :: @wndCompletionCursor
+					elif(sel <> 0)
+						do sel :- 1
 					end if
+					do @wndCompletionListKeywords.setSel(sel)
+					do @wndCompletionListKeywordsOnSel(@wndCompletionListKeywords)
 				end if
-				do @wndCompletionListKeywords.setSel(sel)
-				do @wndCompletionListKeywordsOnSel(@wndCompletionListKeywords)
 			elif(shiftCtrl = %ctrl)
 				do me.scrollPageY(-1)
 			else
@@ -536,18 +535,17 @@ class DocumentSrc(@Document)
 			ret true
 		case %down
 			if(@wndCompletion <>& null & @wndCompletionListKeywords <>& null)
-				var sel: int :: @wndCompletionListKeywords.getSel()
-				if(sel = -1)
-					do sel :: @wndCompletionCursor
-				else
-					do sel :+ 1
-					var len: int :: @wndCompletionListKeywords.len()
-					if(sel >= len)
-						do sel :: len - 1
+				var len: int :: @wndCompletionListKeywords.len()
+				if(len <> 0)
+					var sel: int :: @wndCompletionListKeywords.getSel()
+					if(sel = -1)
+						do sel :: @wndCompletionCursor
+					elif(sel <> len - 1)
+						do sel :+ 1
 					end if
+					do @wndCompletionListKeywords.setSel(sel)
+					do @wndCompletionListKeywordsOnSel(@wndCompletionListKeywords)
 				end if
-				do @wndCompletionListKeywords.setSel(sel)
-				do @wndCompletionListKeywordsOnSel(@wndCompletionListKeywords)
 			elif(shiftCtrl = %ctrl)
 				do me.scrollPageY(1)
 			else


### PR DESCRIPTION
Kuinエディタで、起動直後に間髪を置かず適当に文字を入力すると空の状態の単語補完リストが表示されます。

その状態で、カーソルキーの[↑]か[↓]を押すと_listSetSel(wnd@List.setSel)で範囲外の例外0xE9170006(Argument
outside the domain.)が発生します。この不具合を修正しました。