### PR TITLE
【Kuinエディタ】配列の範囲外アクセスの修正

### DIFF
--- a/src/kuin_editor/kuin_editor.kn
+++ b/src/kuin_editor/kuin_editor.kn
@@ -1272,10 +1272,10 @@ class DocumentSrc(@Document)
 		do me.undo.recordBegin()
 		for i(y1, y2)
 			if(^me.src.src[i] > 0 & me.src.src[i][0] = '\t')
-				if(i = oldAreaY & oldAreaX > 0 & me.src.src[i][oldAreaX] <> '\t')
+				if(i = oldAreaY & oldAreaX > 0 & oldAreaX < ^me.src.src[i] & me.src.src[i][oldAreaX] <> '\t')
 					do oldAreaX :- 1
 				end if
-				if(i = oldCursorY & oldCursorX > 0 & me.src.src[i][oldCursorX] <> '\t')
+				if(i = oldCursorY & oldCursorX > 0 & oldCursorX < ^me.src.src[i] & me.src.src[i][oldCursorX] <> '\t')
 					do oldCursorX :- 1
 				end if
 				do me.del(0, i, 1, true)


### PR DESCRIPTION
範囲選択をした状態でShift+Tabを押したときに、例外「Array index out of
range.」(0xE9170002)が発生することがあったため、修正しました。