### PR TITLE
【Kuinエディタ】情報リストの選択時の範囲外例外の修正

### DIFF
--- a/src/kuin_editor/kuin_editor.kn
+++ b/src/kuin_editor/kuin_editor.kn
@@ -3672,7 +3672,7 @@ func wndCompletionListKeywordsOnMouseDoubleClick(wnd: wnd@List, x: int, y: int)
 end func
 
 func jumpSrc(pos: @Pos): bool
-	if(pos.src[0] <> '\\')
+	if(pos =& null | pos.src =& null | ^pos.src = 0 | pos.src[0] <> '\\')
 		ret false
 	end if
 	var src: []char :: @internalNameToSrcName(pos.src)


### PR DESCRIPTION
EA0062でエディタの情報リスト(エディタの左側下方に表示されている「@listInfo」)で、IK0000(コンパイル開始)やEA0058(「main」関数が存在しません。)などのメッセージをクリックした場合に、範囲外例外となるのを修正しました。