### PR TITLE
「予期せぬエラー」の修正

### DIFF
--- a/src/compiler/analyze.c
+++ b/src/compiler/analyze.c
@@ -3208,7 +3208,7 @@ static SAstExpr* RebuildExprCall(SAstExprCall* ast)
 		return (SAstExpr*)DummyPtr;
 	{
 		SAstTypeFunc* type = (SAstTypeFunc*)ast->Func->Type;
-		if ((type->FuncAttr & FuncAttr_MakeInstance) != 0)
+		if (((SAst*)type)->TypeId == AstTypeId_TypeFunc && (type->FuncAttr & FuncAttr_MakeInstance) != 0)
 		{
 			// Make an instance and add it to the second argument when '_make_instance' is specified.
 			SAstExprCallArg* value_type = (SAstExprCallArg*)Alloc(sizeof(SAstExprCallArg));


### PR DESCRIPTION
kuin.exeでコンパイル時に「予期せぬエラー」が出るのを修正しました。
下記のコードで発生します。本来は「EA0046 関数でないものを関数呼び出ししようとしました。」となるはずのコードです。
```
func main()
	var arr: []char
	do arr()
end func
```