### PR TITLE
cui@printの文字コードをUTF-8に変更

### DIFF
--- a/src/kuin_editor/kuin_editor.kn
+++ b/src/kuin_editor/kuin_editor.kn
@@ -1305,14 +1305,14 @@ class DocumentSrc(@Document)
 			if(str[i] = '\n')
 				var line: []char :: me.src.src[y].sub(x, -1)
 				do me.src.src[y] :: me.src.src[y].sub(0, x)
-				do me.src.color[y] :: #[^me.src.src[y]]bit8
+				do me.src.color[y] :: me.src.color[y].sub(0, x)
 				do me.src.src :: me.src.src.sub(0, y + 1) ~ [line] ~ me.src.src.sub(y + 1, -1)
 				do me.src.color :: me.src.color.sub(0, y + 1) ~ [#[^line]bit8] ~ me.src.color.sub(y + 1, -1)
 				do x :: 0
 				do y :+ 1
 			else
 				do me.src.src[y] :: me.src.src[y].sub(0, x) ~ str[i].toStr() ~ me.src.src[y].sub(x, -1)
-				do me.src.color[y] :: #[^me.src.src[y]]bit8
+				do me.src.color[y] :: me.src.color[y].sub(0, x) ~ #[1]bit8 ~ me.src.color[y].sub(x, -1)
 				do x :+ 1
 			end if
 		end for
@@ -1348,7 +1348,7 @@ class DocumentSrc(@Document)
 					do undoStr :: "\n" ~ undoStr
 					var x2: int :: ^me.src.src[y - 1]
 					do me.src.src[y - 1] :~ me.src.src[y]
-					do me.src.color[y - 1] :: #[^me.src.src[y - 1]]bit8
+					do me.src.color[y - 1] :~ me.src.color[y]
 					do me.src.src :: me.src.src.sub(0, y) ~ me.src.src.sub(y + 1, -1)
 					do me.src.color :: me.src.color.sub(0, y) ~ me.src.color.sub(y + 1, -1)
 					do y :- 1
@@ -1357,7 +1357,7 @@ class DocumentSrc(@Document)
 			else
 				do undoStr :: me.src.src[y][x - 1].toStr() ~ undoStr
 				do me.src.src[y] :: me.src.src[y].sub(0, x - 1) ~ me.src.src[y].sub(x, -1)
-				do me.src.color[y] :: #[^me.src.src[y]]bit8
+				do me.src.color[y] :: me.src.color[y].sub(0, x - 1) ~ me.src.color[y].sub(x, -1)
 				do x :- 1
 			end if
 		end for
@@ -1391,14 +1391,14 @@ class DocumentSrc(@Document)
 				if(y <> ^me.src.src - 1)
 					do undoStr :~ "\n"
 					do me.src.src[y] :~ me.src.src[y + 1]
-					do me.src.color[y] :: #[^me.src.src[y]]bit8
+					do me.src.color[y] :~ me.src.color[y + 1]
 					do me.src.src :: me.src.src.sub(0, y + 1) ~ me.src.src.sub(y + 2, -1)
 					do me.src.color :: me.src.color.sub(0, y + 1) ~ me.src.color.sub(y + 2, -1)
 				end if
 			else
 				do undoStr :~ me.src.src[y][x].toStr()
 				do me.src.src[y] :: me.src.src[y].sub(0, x) ~ me.src.src[y].sub(x + 1, -1)
-				do me.src.color[y] :: #[^me.src.src[y]]bit8
+				do me.src.color[y] :: me.src.color[y].sub(0, x) ~ me.src.color[y].sub(x + 1, -1)
 			end if
 		end for
 		if(recordUndo)
@@ -1602,9 +1602,8 @@ class DocumentSrc(@Document)
 		if(indent < 0)
 			do indent :: 0
 		end if
-		var replaceStr: []char :: "\t".repeat(indent) ~ (curIndent = -1 ?("", me.src.src[y].sub(curIndent, -1)))
-		do me.del(0, y, ^me.src.src[y], true)
-		do me.ins(0, y, replaceStr, true)
+		do me.del(0, y, curIndent = -1 ?(^me.src.src[y], curIndent), true)
+		do me.ins(0, y, "\t".repeat(indent), true)
 		do me.cursorX :: indent
 	end func
 

--- a/src/kuincl/main.c
+++ b/src/kuincl/main.c
@@ -36,7 +36,7 @@ int wmain(int argc, Char** argv)
 	Bool not_deploy = False;
 	Quiet = False;
 
-	_setmode(_fileno(stdout), _O_U16TEXT); // Set the output format to UTF-16.
+	_setmode(_fileno(stdout), _O_U8TEXT); // Set the output format to UTF-8.
 	{
 		int i;
 		for (i = 1; i < argc; i++)

--- a/src/lib_cui/main.c
+++ b/src/lib_cui/main.c
@@ -25,7 +25,7 @@ EXPORT void _init(void* heap, S64* heap_cnt, S64 app_code, const U8* use_res_fla
 	Instance = (HINSTANCE)GetModuleHandle(NULL);
 
 	wprintf(L""); // Open 'stdout'
-	_setmode(_fileno(stdout), _O_U16TEXT); // Set the output format to UTF-16.
+	_setmode(_fileno(stdout), _O_U8TEXT); // Set the output format to UTF-8.
 }
 
 EXPORT void _fin(void)

--- a/src/test_src/main.c
+++ b/src/test_src/main.c
@@ -22,7 +22,7 @@ static Bool Compare(const Char* path1, const Char* path2);
 int wmain(void)
 {
 	int type;
-	_setmode(_fileno(stdout), _O_U16TEXT);
+	_setmode(_fileno(stdout), _O_U8TEXT); // Set the output format to UTF-8.
 	wprintf(L"-1 = Just build 'test.kn'.\n");
 	wprintf(L" 0 = Run all the tests.\n");
 	wprintf(L"> ");


### PR DESCRIPTION
#27 (cui@print、cui@inputの文字コードについて)に関連します。
現状は、
```
func main()
 do cui@print(cui@input())
end func
```
というプログラム(out.exeとします)に関する動作で、
echo abc | out.exe
はabcを出力しますが、
echo abc | out.exe | out.exe
はaのみを出力してしまいます。
(※コマンドプロンプトのコードページの設定等にも依っては期待通りの動作をするかもしれませんが、詳しく調べていません。)

上記の動作を改善するためにも、cui@printで出力される文字コードをUTF-8に変更しました。