### PR TITLE
cui@inputで標準入力から読み取る文字列の文字符号化方式をUTF-8に変更

### DIFF
--- a/src/lib_cui/main.c
+++ b/src/lib_cui/main.c
@@ -25,6 +25,7 @@ EXPORT void _init(void* heap, S64* heap_cnt, S64 app_code, const U8* use_res_fla
 	Instance = (HINSTANCE)GetModuleHandle(NULL);
 
 	wprintf(L""); // Open 'stdout'
+	_setmode(_fileno(stdin), _O_U8TEXT); // Set the input format to UTF-8.
 	_setmode(_fileno(stdout), _O_U8TEXT); // Set the output format to UTF-8.
 }
 


### PR DESCRIPTION
cui@inputで標準入力から読み取るられる文字列をUTF-8として解釈するように変更しました。
#27 (cui@print、cui@inputの文字コードについて)に関連した対応です。