### PR TITLE
「予期せぬエラー」の修正

### DIFF
--- a/src/compiler/analyze.c
+++ b/src/compiler/analyze.c
@@ -2101,7 +2101,7 @@ static SAstStat* RebuildBreak(SAstStat* ast, SAstType* ret_type)
 	if (((SAst*)ast)->AnalyzedCache != NULL)
 		return (SAstStat*)((SAst*)ast)->AnalyzedCache;
 	((SAst*)ast)->AnalyzedCache = (SAst*)ast;
-	if ((((SAst*)ast)->RefItem->TypeId & AstTypeId_StatBreakable) != AstTypeId_StatBreakable)
+	if (((SAst*)ast)->RefItem == NULL || (((SAst*)ast)->RefItem->TypeId & AstTypeId_StatBreakable) != AstTypeId_StatBreakable)
 	{
 		Err(L"EA0033", ((SAst*)ast)->Pos);
 		return (SAstStat*)DummyPtr;


### PR DESCRIPTION
下記コードのコンパイル時に「予期せぬエラー」が発生するのを修正しました。
```
func main()
	break i
end func
```
※元々 `EA0000: 識別子「i」の定義が見つかりません。` になるコードです。