### PR TITLE
「予期せぬエラー」の修正 (skip文)

### DIFF
--- a/src/compiler/analyze.c
+++ b/src/compiler/analyze.c
@@ -2118,7 +2118,7 @@ static SAstStat* RebuildSkip(SAstStat* ast, SAstType* ret_type)
 	if (((SAst*)ast)->AnalyzedCache != NULL)
 		return (SAstStat*)((SAst*)ast)->AnalyzedCache;
 	((SAst*)ast)->AnalyzedCache = (SAst*)ast;
-	if ((((SAst*)ast)->RefItem->TypeId & AstTypeId_StatSkipable) != AstTypeId_StatSkipable)
+	if (((SAst*)ast)->RefItem == NULL || (((SAst*)ast)->RefItem->TypeId & AstTypeId_StatSkipable) != AstTypeId_StatSkipable)
 	{
 		Err(L"EA0034", ((SAst*)ast)->Pos);
 		return (SAstStat*)DummyPtr;


### PR DESCRIPTION
(#88 でbreakに関する不具合は修正済みですが、skipにも同じ問題がありました。)

下記コードのコンパイル時に「予期せぬエラー」が発生するのを修正しました。
```
func main()
	skip i
end func
```
※元々 `EA0000: 識別子「i」の定義が見つかりません。` になるコードです。