### PR TITLE
Fix integer overflow of 'math@lcm' function

### DIFF
--- a/src/lib_math/main.c
+++ b/src/lib_math/main.c
@@ -101,7 +101,7 @@ EXPORT S64 _lcm(S64 a, S64 b)
 		a = -a;
 	if (b < 0)
 		b = -b;
-	return a * b / _gcd(a, b);
+	return a / _gcd(a, b) * b;
 }
 
 EXPORT S64 _modPow(S64 value, S64 exponent, S64 modulus)


### PR DESCRIPTION
現在の `math@lcm` の実装は，`a` と `b` の最小公倍数が `int` で表現できる大きさであっても，`a * b` がオーバーフローする場合は正しい結果を返さないようなので，これを修正しました。

```
func main()
  do cui@print("\{math@lcm(20000000000, 30000000000)}")
  ; 修正前: -874255443
  ; 修正後: 60000000000
end func
```