### PR TITLE
Fix a issue: Array index out of range.

### DIFF
--- a/src/kuin_editor/completion.kn
+++ b/src/kuin_editor/completion.kn
@@ -24,7 +24,7 @@ end func
 	if(@wndCompletion =& null)
 		do @keywords :: #list<[]char>
 		do \dll@getKeywords(src, srcName, posX, posY, getKeywordsCallback)
-		if(^@keywords = 0)
+		if(^@keywords = 0 | ^word = 0)
 			do @close()
 			ret
 		end if


### PR DESCRIPTION
Kuinエディタで、`do`のdの直前にカーソルがあるときにDeleteキーを押してdを削除すると、`\completion@show`関数の引数の`word`が空文字列となります。
この結果、関数後半のword[0]で `Array index out of range.` が発生していました。