### PR TITLE
常にfalseになっているコードを修正しました。

### DIFF
--- a/src/compiler/parse.c
+++ b/src/compiler/parse.c
@@ -6022,7 +6022,7 @@ static void GetKeywordsAddMember(const Char* type)
 		return;
 	if (type[0] == L'b' && type[1] == L'i' && type[2] == L't')
 	{
-		if (type[3] == L'1' && type[4] == L'6' || type[3] == L'3' && type[3] == L'2' || type[3] == L'6' && type[3] == L'4' || type[3] == L'8')
+		if (type[3] == L'1' && type[4] == L'6' || type[3] == L'3' && type[4] == L'2' || type[3] == L'6' && type[4] == L'4' || type[3] == L'8')
 		{
 			GetKeywordsAdd(L"and");
 			GetKeywordsAdd(L"endian");


### PR DESCRIPTION
`type[3] == L'3' && type[3] == L'2'` も `type[3] == L'6' && type[3] == L'4'` も常に falseです。
修正しました。