### PR TITLE
Fix a issue: Array index out of range.

### DIFF
--- a/src/kuin_editor/completion.kn
+++ b/src/kuin_editor/completion.kn
@@ -15,6 +15,10 @@ var keywords: list<[]char>
 end func
 
 +func show(src: kuin@Class, srcName: []char, posX: int, posY: int, word: []char)
+	if(^word = 0)
+		do @close()
+		ret
+	end if
 	if(@wndCompletion <>& null)
 		if(@oldX <> posX | @oldY <> posY)
 			do @close()
@@ -24,7 +28,7 @@ end func
 	if(@wndCompletion =& null)
 		do @keywords :: #list<[]char>
 		do \dll@getKeywords(src, srcName, posX, posY, getKeywordsCallback)
-		if(^@keywords = 0 | ^word = 0)
+		if(^@keywords = 0)
 			do @close()
 			ret
 		end if


### PR DESCRIPTION
以前のプルリクエスト(#96)による修正が不完全でした。
#96 では、`@wndCompletion =& null` の場合しか修正できていませんでした。

例えば、`do`のdの直後にカーソルがあるときにBackspaceキーを押してdを削除した後、
もう一度dを入力した後、再度Backspaceキーを押すことで、`@wndCompletion <>& null` の状態で`word`が空文字列となります。
この結果、#96と同様に関数後半のword[0]で `Array index out of range.` が発生していました。