### PR TITLE
【Kuinエディタ】コマンドライン引数のファイルの読み込みに失敗した時の処理を修正

### DIFF
--- a/src/kuin_editor/kuin_editor.kn
+++ b/src/kuin_editor/kuin_editor.kn
@@ -14,7 +14,8 @@ func main()
 
 	if(^lib@cmdLine() > 0)
 		do \src@openMainSrc(lib@cmdLine()[0].replace("\\", "/"))
-	else
+	end if
+	if(\src@curDoc =& null)
 		do \src@newMainSrc()
 	end if
 


### PR DESCRIPTION
コマンドライン引数に存在しないファイル名を指定した場合に異常終了していたので修正しました。