### PR TITLE
【Kuinエディタ】resフォルダを開こうとすると落ちる不具合の修正

### DIFF
--- a/src/kuin_editor/form.kn
+++ b/src/kuin_editor/form.kn
@@ -950,7 +950,10 @@ func openResFolder()
 	end if
 	var path: []char :: file@dir(\src@mainSrcDir) ~ "res/"
 	if(!file@exist(path))
-		do file@makeDir(path)
+		if(!file@makeDir(path))
+			do wnd@msgBox(@wndMain, \common@langEn ?("Failed to create res folder.", "resフォルダの作成に失敗しました。"), \common@title, %err, %ok)
+			ret
+		end if
 	end if
 	do task@open(path)
 end func


### PR DESCRIPTION
[編集-「res」フォルダを開く]を実行したときに、「res」フォルダが作れない場合にKuinエディタが落ちる不具合があったので修正しました。