### PR TITLE
.gitignoreに*.VC.dbを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@
 *.ps
 *.opendb
 /test/output/
+*.VC.db


### PR DESCRIPTION
私はVS2015 Professional Editionを使っています。Visual Studioがkuin.VC.dbというファイルを生成し、Visual Studioでソリューションを開くたびにこのファイルが変更されるので.gitignoreに該当記述の追加をお願いいたしたく、よろしくお願いします。