### PR TITLE
【Kuinエディタ】tex.pngが見つからない不具合の修正。

### DIFF
--- a/src/kuin_editor/common.kn
+++ b/src/kuin_editor/common.kn
@@ -20,7 +20,7 @@
 
 	do @font :: draw@makeFont("Consolas", @fontSize, false, false, false, @cellWidth $ float)
 	do @fontP :: draw@makeFont("Consolas", @fontSize, false, false, true, 0.0)
-	do @tex :: draw@makeTex("res/tex.png")
+	do @tex :: draw@makeTex("\{file@exeDir()}res/tex.png")
 end func
 
 +func nullStr(s: []char): []char


### PR DESCRIPTION
カレントディレクトリが `kuin.exe` の置かれているディレクトリでない場合に、 `tex.png` が見つからず、 `kuin.exe` を正常起動できない不具合が発生していたので修正しました。

1週間ほど前のコミット( 475085f656b0d985d625a1f21560abb76160986c `- カレントディレクトリがexeの位置に書き換わっていたのを、書き換えない`)以降で発生していました。