### PR TITLE
cui@inputで1024字以上読めるようにしました。

### DIFF
--- a/src/lib_cui/cui.c
+++ b/src/lib_cui/cui.c
@@ -17,21 +17,43 @@ EXPORT void _print(const U8* str)
 
 EXPORT void* _input(void)
 {
-	Char buf[INPUT_SIZE];
-	if (fgetws(buf, INPUT_SIZE, stdin) == NULL)
-		buf[0] = L'\0';
+	Char *buf = NULL;
+	size_t len = 0;
+	size_t pos = 0;
+	for (; ; )
 	{
-		size_t len = wcslen(buf);
-		U8* result;
-		if (len > 0 && buf[len - 1] == L'\n')
+		if (pos == len)
 		{
-			buf[len - 1] = L'\0';
-			len--;
+			Char *tmp;
+			len += INPUT_SIZE;
+			tmp = (Char *)realloc(buf, sizeof(Char) * len);
+			if (tmp)
+			{
+				buf = tmp;
+			}
+			else
+			{
+				// TODO: Add exception.
+				free(buf);
+				return NULL;
+			}
 		}
-		result = (U8*)AllocMem(0x10 + sizeof(Char) * (len + 1));
+		{
+			Char c = fgetwc(stdin);
+			if (c == L'\n' || c == WEOF)
+				break;
+			buf[pos] = c;
+		}
+		pos++;
+	}
+	buf[pos] = L'\0';
+	len = pos + 1;
+	{
+		U8* result = (U8*)AllocMem(0x10 + sizeof(Char) * (len + 1));
 		((S64*)result)[0] = DefaultRefCntFunc;
 		((S64*)result)[1] = (S64)len;
 		memcpy(result + 0x10, buf, sizeof(Char) * (len + 1));
+		free(buf);
 		return result;
 	}
 }


### PR DESCRIPTION
1行が1024字以上の場合でも `cui@input()` で取得できるようにしました。

競技プログラミングのサイトの yukicoder で、Kuinのコードを提出できるようになりました。
いくつかの問題に解答コードを提出したところ、1行が1024字以上のケースでの入力の受け取りが困難だということに気付いたため、改善しました。