### PR TITLE
【Kuinエディタ】補完に関する動作の修正

### DIFF
--- a/src/kuin_editor/doc_src.kn
+++ b/src/kuin_editor/doc_src.kn
@@ -216,6 +216,7 @@ end func
 			do me.areaY :: me.cursorY
 		end if
 		do me.interpret1SetDirty(me.cursorY, false, false)
+		do \completion@close()
 		do \form@paintDrawEditor()
 	end func
 
@@ -379,6 +380,7 @@ end func
 				do me.cursorY :: lib@intMax
 			end if
 			do me.refreshCursor(false, true)
+			do \completion@close()
 			do \form@paintDrawEditor()
 			do me.interpret1SetDirty(me.cursorY, false, false)
 			ret true
@@ -389,6 +391,7 @@ end func
 				do me.cursorY :: 0
 			end if
 			do me.refreshCursor(false, true)
+			do \completion@close()
 			do \form@paintDrawEditor()
 			do me.interpret1SetDirty(me.cursorY, false, false)
 			ret true
@@ -401,6 +404,7 @@ end func
 				do me.refreshCursor(false, true)
 				do me.interpret1SetDirty(me.cursorY, false, false)
 			end if
+			do \completion@close()
 			do \form@paintDrawEditor()
 			ret true
 		case %up
@@ -428,6 +432,7 @@ end func
 				do me.refreshCursor(true, true)
 				do me.interpret1SetDirty(me.cursorY, false, false)
 			end if
+			do \completion@close()
 			do \form@paintDrawEditor()
 			ret true
 		case %down


### PR DESCRIPTION
カーソル移動後も補完リストが表示されたままになっていることにより後述の不具合がありました。
そのため、 `←`, `→`, `Home`, `End` キーの入力時と左クリック時は補完リストを消すようにしました。

修正前のKuinエディタでは、例えば、下記のコードの3行目の行末に strと入力した後で、「←」キーを3回押してsの前にカーソル移動し、 `^` を入力したときに、 `str^r` となってしまいます。
```
func main()
	var str: []int
	var len: int :: 
end func
```