### PR TITLE
【Kuinエディタ】「選択範囲をスニペットに追加」の反映をすぐに行うように修正

### DIFF
--- a/src/kuin_editor/form.kn
+++ b/src/kuin_editor/form.kn
@@ -543,6 +543,7 @@ func wndMainOnPushMenu(wnd: wnd@WndBase, id: int)
 		do \find@findNext()
 	case 0x003D
 		do \snippet@add(\src@curDoc.getSelCode())
+		do \src@curDoc.fix()
 	case 0x003E
 		if(@lockingEditor)
 			do @showMsgRunning()


### PR DESCRIPTION
#121 ([エディタ]選択範囲をスニペットに追加がすぐに反映されない ) の修正です。