### PR TITLE
sqlライブラリへ機能を追加しました

### DIFF
--- a/package/sys/sql.kn
+++ b/package/sys/sql.kn
@@ -23,6 +23,9 @@ end func
 	+func [d1005.knd, _sqlNext] next(): bool
 	end func
 
+	+func [d1005.knd,_sqlGetBlob8] getBlob8(col: int): []bit8
+	end func
+
 	var db: int
 	var statement: int
 	var result: int

--- a/package/sys/sql.kn
+++ b/package/sys/sql.kn
@@ -26,6 +26,9 @@ end func
 	+func [d1005.knd,_sqlGetBlob8] getBlob8(col: int): []bit8
 	end func
 
+	+func [d1005.knd,_sqlErrMsg] errMsg(): []char
+	end func
+
 	var db: int
 	var statement: int
 	var result: int

--- a/src/lib_sql/main.c
+++ b/src/lib_sql/main.c
@@ -120,6 +120,19 @@ EXPORT void* _sqlGetStr(SClass* me_, S64 col)
 	return result;
 }
 
+EXPORT void* _sqlGetBlob8(SClass* me_, S64 col)
+{
+	SSql* me2 = (SSql*)me_;
+	THROWDBG(me2->Db == NULL, EXCPT_DBG_INOPERABLE_STATE);
+	size_t len = sqlite3_column_bytes(me2->Statement, (int)col);
+	const S8* blob = sqlite3_column_blob(me2->Statement, (int)col);
+	U8* result = (U8*)AllocMem(0x10 + sizeof(S8) * len);
+	((S64*)result)[0] = DefaultRefCntFunc;
+	((S64*)result)[1] = (S64)len;
+	memcpy(result + 0x10, blob, sizeof(S8) * len);
+	return result;
+}
+
 EXPORT Bool _sqlNext(SClass* me_)
 {
 	SSql* me2 = (SSql*)me_;

--- a/src/lib_sql/main.c
+++ b/src/lib_sql/main.c
@@ -133,6 +133,19 @@ EXPORT void* _sqlGetBlob8(SClass* me_, S64 col)
 	return result;
 }
 
+EXPORT void* _sqlErrMsg(SClass* me_)
+{
+	SSql* me2 = (SSql*)me_;
+	THROWDBG(me2->Db == NULL, EXCPT_DBG_INOPERABLE_STATE);
+	const Char* str = sqlite3_errmsg16(me2->Db);
+	size_t len = wcslen(str);
+	U8* result = (U8*)AllocMem(0x10 + sizeof(Char) * (len + 1));
+	((S64*)result)[0] = DefaultRefCntFunc;
+	((S64*)result)[1] = (S64)len;
+	memcpy(result + 0x10, str, sizeof(Char) * (len + 1));
+	return result;
+}
+
 EXPORT Bool _sqlNext(SClass* me_)
 {
 	SSql* me2 = (SSql*)me_;

--- a/src/lib_sql/main.h
+++ b/src/lib_sql/main.h
@@ -10,4 +10,5 @@ EXPORT Bool _sqlExec(SClass* me_, const void* cmd);
 EXPORT S64 _sqlGetInt(SClass* me_, S64 col);
 EXPORT double _sqlGetFloat(SClass* me_, S64 col);
 EXPORT void* _sqlGetStr(SClass* me_, S64 col);
+EXPORT void* _sqlGetBlob8(SClass* me_, S64 col);
 EXPORT Bool _sqlNext(SClass* me_);

--- a/src/lib_sql/main.h
+++ b/src/lib_sql/main.h
@@ -9,6 +9,7 @@ EXPORT void _sqlFin(SClass* me_);
 EXPORT Bool _sqlExec(SClass* me_, const void* cmd);
 EXPORT S64 _sqlGetInt(SClass* me_, S64 col);
 EXPORT double _sqlGetFloat(SClass* me_, S64 col);
+EXPORT void* _sqlErrMsg(SClass* me_);
 EXPORT void* _sqlGetStr(SClass* me_, S64 col);
 EXPORT void* _sqlGetBlob8(SClass* me_, S64 col);
 EXPORT Bool _sqlNext(SClass* me_);


### PR DESCRIPTION
sqlライブラリに、以下2つの機能を追加してみました。

### getBlob8関数

    func getBlob8(col: int): []bit8

SQLiteではデータ型にBLOBが使えるため、Kuinの[]bit8で取得できるとバイナリを扱えるので作成しました。使い方としてはsql@getIntやsql@getFloat、sql@getStrでの使い方と同じように、列をcolで指定します。

### errMsg関数

    func errMsg(): []char

エラーメッセージを返します。sql@execなどで構文が間違っているときなどで取得できます。中身は[sqlite3_errmsg16](https://www.sqlite.org/c3ref/errcode.html) です。

テストとして次のようなコードを書いて確認しました: <https://gist.github.com/youkidearitai/c597c3039539ece96bd3e627fd37999e>
