### PR TITLE
補完機能の修正

### DIFF
--- a/src/kuin_editor/doc_src.kn
+++ b/src/kuin_editor/doc_src.kn
@@ -1691,7 +1691,7 @@ end func
 			ret null
 		end if
 		var last: int :: x
-		while(last < ^me.src.color[y] - 1 & keyword(me.src.color[y][last + 1]))
+		while(last < ^me.src.color[y] & keyword(me.src.color[y][last]))
 			do last :+ 1
 		end while
 		ret me.src.src[y].sub(first, last - first).trim()


### PR DESCRIPTION
例えば以下のコードで、 3行目の abcd の a の手前にカーソルを置いて、スペースキーを2回押すと「abcd d」になっていました。
```
func main()
	var abcd: int :: 0
	var xxxx: int :: abcd
end func
```

これを修正しました。