### PR TITLE
Web版の標準入力対応

### DIFF
--- a/src/lib/sys/cui.kn
+++ b/src/lib/sys/cui.kn
@@ -16,7 +16,6 @@ end func
 end func
 
 +func input(): []char
-#exe,cpp
 	var buf: []char :: #[@bufSizeMin]char
 	var ptr: int :: 0
 	while loop(true)
@@ -40,13 +39,9 @@ end func
 		do ptr :+ 1
 	end while
 	ret buf.sub(0, ptr)
-#web
-	ret null
-#any
 end func
 
 +func inputChar(): char
-#exe,cpp
 	while loop(true)
 		var c: char :: @inputCharWithDelimiter()
 		if(c <> '\0')
@@ -56,13 +51,9 @@ end func
 			ret c
 		end if
 	end while
-#web
-	ret 0 $ char
-#any
 end func
 
 +func inputFloat(): float
-#exe,cpp
 	var s: []char :: @inputStr()
 	var b: bool
 	var r: float :: s.toFloat(&b)
@@ -70,13 +61,9 @@ end func
 		throw 0xE9170008
 	end if
 	ret r
-#web
-	ret 0.0
-#any
 end func
 
 +func inputInt(): int
-#exe,cpp
 	var s: []char :: @inputStr()
 	var b: bool
 	var r: int :: s.toInt(&b)
@@ -84,9 +71,6 @@ end func
 		throw 0xE9170008
 	end if
 	ret r
-#web
-	ret 0
-#any
 end func
 
 #exe
@@ -113,12 +97,12 @@ end func
 	excode "return static_cast<char16_t>(u_);\n"
 	excode "#endif\n"
 #web
-	ret 0 $ char
+	excode "if(O_&&O_.inputLetter){return O_.inputLetter();}\n"
+	excode "return 0xffff;\n"
 #any
 end func
 
 +func inputStr(): []char
-#exe,cpp
 	var buf: []char :: #[@bufSizeMin]char
 	var ptr: int :: 0
 	while loop(true)
@@ -142,9 +126,6 @@ end func
 		do ptr :+ 1
 	end while
 	ret buf.sub(0, ptr)
-#web
-	ret null
-#any
 end func
 
 #exe
@@ -170,7 +151,6 @@ end func
 #any
 end func
 
-#exe,cpp
 func inputCharWithDelimiter(): char
 	while loop(true)
 		var c: char :: @inputLetter()

--- a/src/sys/web/cui.kn
+++ b/src/sys/web/cui.kn
@@ -9,27 +9,92 @@ end func
 end func
 
 +func input(): []char
-	ret null
+	var buf: []char :: #[@bufSizeMin]char
+	var ptr: int :: 0
+	while loop(true)
+		var c: char :: @inputLetter()
+		if(c = '\u000D')
+			skip loop
+		end if
+		if(c = '\uFFFF')
+			if(ptr = 0)
+				ret null
+			end if
+			break loop
+		end if
+		if(c = '\n')
+			break loop
+		end if
+		if(ptr = ^buf)
+			do buf :~ #[^buf]char
+		end if
+		do buf[ptr] :: c
+		do ptr :+ 1
+	end while
+	ret buf.sub(0, ptr)
 end func
 
 +func inputChar(): char
-	ret 0 $ char
+	while loop(true)
+		var c: char :: @inputCharWithDelimiter()
+		if(c <> '\0')
+			if(c = '\uFFFF')
+				throw 0xE9170008
+			end if
+			ret c
+		end if
+	end while
 end func
 
 +func inputFloat(): float
-	ret 0.0
+	var s: []char :: @inputStr()
+	var b: bool
+	var r: float :: s.toFloat(&b)
+	if(!b)
+		throw 0xE9170008
+	end if
+	ret r
 end func
 
 +func inputInt(): int
-	ret 0
+	var s: []char :: @inputStr()
+	var b: bool
+	var r: int :: s.toInt(&b)
+	if(!b)
+		throw 0xE9170008
+	end if
+	ret r
 end func
 
 +func inputLetter(): char
-	ret 0 $ char
+	excode "if(O_&&O_.inputLetter){return O_.inputLetter();}\n"
+	excode "return 0xffff;\n"
 end func
 
 +func inputStr(): []char
-	ret null
+	var buf: []char :: #[@bufSizeMin]char
+	var ptr: int :: 0
+	while loop(true)
+		var c: char :: @inputCharWithDelimiter()
+		if(c = '\uFFFF')
+			if(ptr = 0)
+				throw 0xE9170008
+			end if
+			break loop
+		end if
+		if(c = '\0')
+			if(ptr = 0)
+				skip loop
+			end if
+			break loop
+		end if
+		if(ptr = ^buf)
+			do buf :~ #[^buf]char
+		end if
+		do buf[ptr] :: c
+		do ptr :+ 1
+	end while
+	ret buf.sub(0, ptr)
 end func
 
 +func print(str: []char)
@@ -38,3 +103,17 @@ end func
 	excode "console.log(`0`.S);\n"
 end func
 
+func inputCharWithDelimiter(): char
+	while loop(true)
+		var c: char :: @inputLetter()
+		for i(0, ^@delimiters - 1)
+			if(c = @delimiters[i] | (c = '\u000D' & @delimiters[i] = '\n'))
+				ret '\0'
+			end if
+		end for
+		if(c = '\u000D')
+			skip loop
+		end if
+		ret c
+	end while
+end func


### PR DESCRIPTION
`inputLetter` を実装することでWeb版で `cui@inputInt()` などを使えます。

↓ 実際にWeb版で `cui@inputInt()`, `cui@input()` を使用している例。
https://tatt61880.github.io/kuin-web/?src=func%20main()%0A%09var%20a%3A%20int%20%3A%3A%20cui%40inputInt()%0A%09var%20b%3A%20int%20%3A%3A%20cui%40inputInt()%0A%09var%20s%3A%20%5B%5Dchar%20%3A%3A%20cui%40input()%0A%09do%20cui%40print(%22%5C%7Ba%20%2B%20b%7D%20%5C%7Bs%7D%5Cn%22)%0Aend%20func&input=1%202%0Atest

↓ `inputLetter` の実装例 ( https://github.com/tatt61880/kuin-web/blob/gh-pages/js/kuin_web_ui.js )
```
	let input = d.getElementById('input');
```
```
			if (platform === 'run') {
				let inputStr = input.value;
				let data = [];
				for (let i = 0; i < inputStr.length; i++) {
					data.push(inputStr.charCodeAt(i));
				}
				let idx = 0;
				let print =
					function(s) {
						output.value += s;
					};
				let inputLetter =
					function() {
						if (idx < data.length) {
							return data[idx++];
						} else {
							return 0xFFFF;
						}
					};
				eval(code.S + ' if (typeof out !== "undefined") { out({'
					+ 'print:' + print.toString() + ', '
					+ 'inputLetter:' + inputLetter.toString()
					+ '}); }');
			}
```