### PR TITLE
【-e cpp】[lib@intMin, 1].max()が1にならない不具合の修正

### DIFF
--- a/build/output/common.h
+++ b/build/output/common.h
@@ -930,7 +930,7 @@ static int64_t cmp_(type_(Array_<char16_t>) a, type_(Array_<char16_t>) b) {
 	return a->L > b->L ? 1 : (a->L < b->L ? -1 : 0);
 }
 static int64_t cmp_(type_(Class_) a, type_(Class_) b) { return reinterpret_cast<int64_t(*)(type_(Class_), type_(Class_))>(classTable_[a->Y + 3])(a, b); }
-static int64_t cmp_(int64_t a, int64_t b) { return a - b; }
+static int64_t cmp_(int64_t a, int64_t b) { return a > b ? 1LL : (a < b ? -1LL : 0LL); }
 static int64_t cmp_(char16_t a, char16_t b) { return static_cast<int64_t>(a) - static_cast<int64_t>(b); }
 static int64_t cmp_(double a, double b) { return a > b ? 1LL : (a < b ? -1LL : 0LL); }
 static int64_t cmp_(uint8_t a, uint8_t b) { return static_cast<int64_t>(a) - static_cast<int64_t>(b); }

--- a/build/sys/common.h
+++ b/build/sys/common.h
@@ -930,7 +930,7 @@ static int64_t cmp_(type_(Array_<char16_t>) a, type_(Array_<char16_t>) b) {
 	return a->L > b->L ? 1 : (a->L < b->L ? -1 : 0);
 }
 static int64_t cmp_(type_(Class_) a, type_(Class_) b) { return reinterpret_cast<int64_t(*)(type_(Class_), type_(Class_))>(classTable_[a->Y + 3])(a, b); }
-static int64_t cmp_(int64_t a, int64_t b) { return a - b; }
+static int64_t cmp_(int64_t a, int64_t b) { return a > b ? 1LL : (a < b ? -1LL : 0LL); }
 static int64_t cmp_(char16_t a, char16_t b) { return static_cast<int64_t>(a) - static_cast<int64_t>(b); }
 static int64_t cmp_(double a, double b) { return a > b ? 1LL : (a < b ? -1LL : 0LL); }
 static int64_t cmp_(uint8_t a, uint8_t b) { return static_cast<int64_t>(a) - static_cast<int64_t>(b); }

--- a/src/sys/common.h
+++ b/src/sys/common.h
@@ -930,7 +930,7 @@ static int64_t cmp_(type_(Array_<char16_t>) a, type_(Array_<char16_t>) b) {
 	return a->L > b->L ? 1 : (a->L < b->L ? -1 : 0);
 }
 static int64_t cmp_(type_(Class_) a, type_(Class_) b) { return reinterpret_cast<int64_t(*)(type_(Class_), type_(Class_))>(classTable_[a->Y + 3])(a, b); }
-static int64_t cmp_(int64_t a, int64_t b) { return a - b; }
+static int64_t cmp_(int64_t a, int64_t b) { return a > b ? 1LL : (a < b ? -1LL : 0LL); }
 static int64_t cmp_(char16_t a, char16_t b) { return static_cast<int64_t>(a) - static_cast<int64_t>(b); }
 static int64_t cmp_(double a, double b) { return a > b ? 1LL : (a < b ? -1LL : 0LL); }
 static int64_t cmp_(uint8_t a, uint8_t b) { return static_cast<int64_t>(a) - static_cast<int64_t>(b); }


### PR DESCRIPTION
下記のコードを-e cppでトランスパイルしたコードに関して、 `1` が出力されることを期待しましたが、
`-9223372036854775808` が出力されたので、これを修正しました。
(出力されたコードはVisual Studio 2019でコンパイルしました。)
```
func main()
	var x: int :: [lib@intMin, 1].max()
	do cui@print("\{x}\n")
end func
```
ちなみに、 `[lib@intMin, 1].max()` の代わりに `lib@max(lib@intMin, 1)` とした場合は、問題なく `1` が出力されました。