### PR TITLE
test.bat実行時にファイル比較で一致しないのを修正

### DIFF
--- a/build/test.bat
+++ b/build/test.bat
@@ -30,7 +30,7 @@ rem Kuin2.cpp ->[Visual Studio]->Kuin2.exe
 pause
 
 rem Kuin2.kn ->[Kuin2.exe]-> Kuin2.cpp
-.\output\x64\Release\kuin_cpp_ja\kuin_cpp_ja.exe -i "%~dp0../src/compiler/main.kn" -o "%~dp0output/kuin_cpp_ja2" -s "%~dp0output/test_res/sys/" -e cpp -x nogc -x lang=ja
+.\output\x64\Release\kuin_cpp_ja\kuin_cpp_ja.exe -i "%~dp0../src/compiler/main.kn" -o "%~dp0output/kuin_cpp_ja2" -s "%~dp0output/test_res/sys/" -e cpp -r -x nogc -x lang=ja
 
 rem Compare Kuin2.cpp
 fc /N "%~dp0output\kuin_cpp_ja.cpp" "%~dp0output\kuin_cpp_ja2.cpp"


### PR DESCRIPTION
「/build/test.bat」を実行した際、「kuin_cpp_ja.cpp」と「kuin_cpp_ja2.cpp」に差があり、ファイル比較で差分が表示されていました。
ファイル作成時のコマンドライン引数に「-r」があるかないかの違いによるものです。
意図的な差ではないと思われるので修正しました。