### PR TITLE
先頭行での↑キー・最終行での↓キーの動作を変更

### DIFF
--- a/src/kuin_editor/doc_src.kn
+++ b/src/kuin_editor/doc_src.kn
@@ -1223,8 +1223,7 @@ end func
 			do me.cursorY :: 0
 		end if
 		if(me.cursorY >= ^me.src.src)
-			do me.cursorX :: 0
-			ret
+			do me.cursorY :: ^me.src.src - 1
 		end if
 		var left: int :: me.lineNumWidth - me.pageX * \common@cellWidth
 		var x: int :: 0
@@ -1246,16 +1245,19 @@ end func
 		do me.lineNumWidth :: \common@cellWidth * (lib@max(log10(^me.src.src), 3) + 1)
 		
 		if(me.cursorX < 0)
-			do me.cursorX :: lib@intMax
-			do me.cursorY :- 1
+			if(me.cursorY = 0)
+				do me.cursorX :: 0
+			else
+				do me.cursorX :: lib@intMax
+				do me.cursorY :- 1
+			end if
 		end if
 		if(me.cursorY < 0)
-			do me.cursorX :: 0
 			do me.cursorY :: 0
 		end if
 		if(me.cursorY > ^me.src.src - 1)
 			do me.cursorY :: ^me.src.src - 1
-			do me.cursorX :: ^me.src.src[me.cursorY]
+			do me.cursorX :: lib@min(me.cursorX, ^me.src.src[me.cursorY])
 		else
 			if(me.cursorX > ^me.src.src[me.cursorY])
 				if(moveRight & me.cursorY <> ^me.src.src - 1)
@@ -1374,7 +1376,6 @@ end func
 	
 	func setAbsoluteX(absoluteX: int)
 		if(me.cursorY < 0 | ^me.src.src <= me.cursorY)
-			do me.absoluteX :: 0
 			ret
 		end if
 		var x: int :: 0


### PR DESCRIPTION
多くのエディタと同じ動作になるように変更しました。

### 変更前
* 先頭行で ↑ キーを押したとき:  行頭に移動
* 最終行で ↓ キーを押したとき:  行末に移動

### 変更後
* 先頭行で ↑ キーを押したとき:  移動しない
* 最終行で ↓ キーを押したとき:  移動しない
