### PR TITLE
math@permutationNext, math@permutationPrev の動作を変更

### DIFF
--- a/src/lib/sys/math.kn
+++ b/src/lib/sys/math.kn
@@ -162,6 +162,7 @@ end func
 		do left :- 1
 	end while
 	if(left < 0)
+		do array.reverse()
 		ret false
 	end if
 	var right: int :: ^array - 1
@@ -189,6 +190,7 @@ end func
 		do left :- 1
 	end while
 	if(left < 0)
+		do array.reverse()
 		ret false
 	end if
 	var right: int :: ^array - 1

--- a/src/sys/cpp/math.kn
+++ b/src/sys/cpp/math.kn
@@ -162,6 +162,7 @@ end func
 		do left :- 1
 	end while
 	if(left < 0)
+		do array.reverse()
 		ret false
 	end if
 	var right: int :: ^array - 1
@@ -189,6 +190,7 @@ end func
 		do left :- 1
 	end while
 	if(left < 0)
+		do array.reverse()
 		ret false
 	end if
 	var right: int :: ^array - 1

--- a/src/sys/exe/math.kn
+++ b/src/sys/exe/math.kn
@@ -162,6 +162,7 @@ end func
 		do left :- 1
 	end while
 	if(left < 0)
+		do array.reverse()
 		ret false
 	end if
 	var right: int :: ^array - 1
@@ -189,6 +190,7 @@ end func
 		do left :- 1
 	end while
 	if(left < 0)
+		do array.reverse()
 		ret false
 	end if
 	var right: int :: ^array - 1

--- a/src/sys/web/math.kn
+++ b/src/sys/web/math.kn
@@ -162,6 +162,7 @@ end func
 		do left :- 1
 	end while
 	if(left < 0)
+		do array.reverse()
 		ret false
 	end if
 	var right: int :: ^array - 1
@@ -189,6 +190,7 @@ end func
 		do left :- 1
 	end while
 	if(left < 0)
+		do array.reverse()
 		ret false
 	end if
 	var right: int :: ^array - 1


### PR DESCRIPTION
先日導入していただいた `math@permutationNext`, `math@permutationPrev` に関して。

C++ の `next_permutation`, `prev_permutation` と合わせるために、動作を変更しました。
変更前は、falseを返す際に配列を変更していませんでした。
(提案させていただいた際、 C++ の動作の確認不足でした。すみません…。)

異なる言語間でどこまで仕様を合わせるべきか検討の余地はありますが、なるべく合わせておいたほうが混乱は少ないと考えました。

### 動作確認用コード
```
func main()
	var a: []int :: [1, 2, 3]
	while(math@permutationNext(a), skip)
		do cui@print("a = [\{a.join(", ")}]\n")
	end while
	do cui@print("a = [\{a.join(", ")}]\n\n")
	
	var b: []int :: [3, 2, 1]
	while(math@permutationPrev(b), skip)
		do cui@print("b = [\{b.join(", ")}]\n")
	end while
	do cui@print("b = [\{b.join(", ")}]\n")
end func
```

### 実行結果
```
a = [1, 2, 3]
a = [1, 3, 2]
a = [2, 1, 3]
a = [2, 3, 1]
a = [3, 1, 2]
a = [3, 2, 1]
a = [1, 2, 3]

b = [3, 2, 1]
b = [3, 1, 2]
b = [2, 3, 1]
b = [2, 1, 3]
b = [1, 3, 2]
b = [1, 2, 3]
b = [3, 2, 1]
```

### 変更前の実行結果 (参考)
```
a = [1, 2, 3]
a = [1, 3, 2]
a = [2, 1, 3]
a = [2, 3, 1]
a = [3, 1, 2]
a = [3, 2, 1]
a = [3, 2, 1]  ←ここが変更後と異なります。

b = [3, 2, 1]
b = [3, 1, 2]
b = [2, 3, 1]
b = [2, 1, 3]
b = [1, 3, 2]
b = [1, 2, 3]
b = [1, 2, 3]  ←ここが変更後と異なります。
```