### PR TITLE
コンパイル時の経過時間表示を小数点以下3桁に変更

### DIFF
--- a/src/compiler/main.kn
+++ b/src/compiler/main.kn
@@ -74,11 +74,11 @@ func[__rwi]build(): bool
 	
 	do \err@errCnt :: 0
 	var beginTime: int :: lib@sysTime()
-	do \err@err(%compilationStarted, null, [((lib@sysTime() - beginTime) $ float / 1000.0).toStr()])
+	do \err@err(%compilationStarted, null, [((lib@sysTime() - beginTime) $ float / 1000.0).toStrFmt(".3f")])
 	
 	; 'Parse'
 	do asts :: \parse@parse(useResFlags, null)
-	do \err@err(%parsingCompleted, null, [((lib@sysTime() - beginTime) $ float / 1000.0).toStr()])
+	do \err@err(%parsingCompleted, null, [((lib@sysTime() - beginTime) $ float / 1000.0).toStrFmt(".3f")])
 	
 	; Convert to binary files.
 	if(\option@extra.get("binary", &))
@@ -92,7 +92,7 @@ func[__rwi]build(): bool
 	; 'Analyze'
 	var funcAttrs: dict<[]char, dict<[]char, bool>>
 	do entry :: \analyze@analyze(asts, &funcAttrs)
-	do \err@err(%semanticAnalysisCompleted, null, [((lib@sysTime() - beginTime) $ float / 1000.0).toStr()])
+	do \err@err(%semanticAnalysisCompleted, null, [((lib@sysTime() - beginTime) $ float / 1000.0).toStrFmt(".3f")])
 	
 	; Stop compilation if some errors occur.
 	if(\err@errCnt > 0)
@@ -126,7 +126,7 @@ func[__rwi]build(): bool
 		ret false
 	end if
 	
-	do \err@err(%generationProcessCompleted, null, [((lib@sysTime() - beginTime) $ float / 1000.0).toStr()])
+	do \err@err(%generationProcessCompleted, null, [((lib@sysTime() - beginTime) $ float / 1000.0).toStrFmt(".3f")])
 	if(\err@errCnt > 0)
 		ret false
 	end if


### PR DESCRIPTION
変更前は、経過時間の桁数が無駄に多いことがありました。

```
0x00030003: コンパイル開始: 0秒。
0x00030004: 字句構文解析完了: 0.05499999999999999秒。
0x00030005: 意味解析完了: 0.059秒。
0x00030006: 生成処理完了: 0.4389999999999999秒。
0x0003FFFF: 実行。

0x0003FFFF: 正常終了。
```

のように表示されていたのを、
```
0x00030003: コンパイル開始: 0.000秒。
0x00030004: 字句構文解析完了: 0.055秒。
0x00030005: 意味解析完了: 0.059秒。
0x00030006: 生成処理完了: 0.439秒。
0x0003FFFF: 実行。

0x0003FFFF: 正常終了。
```
と表示されるようにしました。