### PR TITLE
「#165 【Kuinエディタ】「コンパイル＆実行」の動作異常」の修正

### DIFF
--- a/build/output/kuin_dll_main.cpp
+++ b/build/output/kuin_dll_main.cpp
@@ -314,8 +314,8 @@ static int64_t FileSize(int64_t handle)
 	for (i = 0; i < len; i++)
 	{
 		total += *reinterpret_cast<int64_t*>(reinterpret_cast<uint8_t*>(*reinterpret_cast<void**>(ptr)) + 0x08);
-		if (total >= 2)
-			return 2; // A value of 2 or more is not distinguished.
+		if (total >= 3)
+			return 3; // A value of 3 or more is not distinguished.
 		ptr = reinterpret_cast<uint8_t*>(ptr) + 0x08;
 	}
 	return total;


### PR DESCRIPTION
#165 の暫定対策です。

`src/compiler/parse.kn` の
`if(fileSize <= 2 & key = "\\" ~ \option@inputName)`
の箇所に関して、 9898e90 のコミットによって `fileSize <= 1` が `fileSize <= 2` に変更されたのは、
Kuinエディタで `q`, `f`, `9` のみのファイルを保存した際に改行が含まれてしまう対策だと思います。

"Kuin言語仕様11 コンパイラとIDE - 3.1入力ファイルの特殊な仕様" https://kuina.ch/kuin/spec11#053225627507
> これらには、改行やスペースなど他の文字を含めてはならない。

「仕様説明に合わせるため、 `q`, `f`, `9` のみのファイルを保存した際に改行を含めないようにする」という方法も考えられますが、やや複雑そうな気がしたので、暫定対策として、 `build/output/kuin_dll_main.cpp` の FileSize 関数を以下のように修正しました。

```
		if (total >= 3)
			return 3; // A value of 3 or more is not distinguished.
```