### PR TITLE
例えば「f + CR + LF」で3バイトになる対策

### DIFF
--- a/build/output/kuin_dll_main.cpp
+++ b/build/output/kuin_dll_main.cpp
@@ -314,8 +314,8 @@ static int64_t FileSize(int64_t handle)
 	for (i = 0; i < len; i++)
 	{
 		total += *reinterpret_cast<int64_t*>(reinterpret_cast<uint8_t*>(*reinterpret_cast<void**>(ptr)) + 0x08);
-		if (total >= 3)
-			return 3; // A value of 3 or more is not distinguished.
+		if (total >= 4)
+			return 4; // A value of 4 or more is not distinguished.
 		ptr = reinterpret_cast<uint8_t*>(ptr) + 0x08;
 	}
 	return total;

--- a/src/compiler/parse.kn
+++ b/src/compiler/parse.kn
@@ -97,7 +97,7 @@ func parseSrc(key: []char, value: \ast@Ast, data: kuin@Class): bool
 	block
 		var reload: []char :: null
 		var fileSize: int :: @fileSizeFunc =& null ?(@filePtr.fileSize(), @fileSizeFunc(@fileHandle))
-		if(fileSize <= 2 & key = "\\" ~ \option@inputName)
+		if(fileSize <= 3 & key = "\\" ~ \option@inputName)
 			var prefix: []char :: \option@env_ = %exe & \option@extra.get("wnd", &) ?("_wnd", "")
 			if(fileSize = 0)
 				do reload :: \option@sysDir ~ \option@getEnvStr(\option@env_) ~ "/_preset00" ~ prefix ~ ".kn"


### PR DESCRIPTION
"Kuin言語仕様11 コンパイラとIDE - 3.1入力ファイルの特殊な仕様" https://kuina.ch/kuin/spec11#053225627507

> これらには、ファイルの末尾に改行を1つ加えることも許容される。 しかしそれ以上の改行やスペースなど他の文字を含めてはならない。

Windowsの標準的な改行コードが1つ加えられている場合、例えば「f + CR + LF」で3バイトのファイルとなり、コンパイルエラーになっていました。

暫定対策として「2バイト以下」ではなく「3バイト以下」のファイルに関してpresetの出力判定を行うようにしました。
(例えば、「`q + CR + LF` の3バイトのファイルに対して `q` が出力される(改行コードが含まれず、Quineとしてやや不完全)」「`qqq` がコンパイルエラーにならない (`q` が出力される)」などの問題は残っていますが、厳密な対応にはやや複雑な修正が必要そうなので暫定対策にとどめました。)