### PR TITLE
範囲選択状態での行入れ替え(Alt+↑, Alt+↓)対応

### DIFF
--- a/src/kuin_editor/doc_src.kn
+++ b/src/kuin_editor/doc_src.kn
@@ -433,21 +433,38 @@ end func
 				do me.scrollPageY(-1)
 				do \form@paintDrawEditor(false)
 			elif(wnd@key(%alt))
-				if(me.cursorY <> 0 & !me.areaSel())
-					do me.undoRecordBegin()
-					var src: []char :: me.src.src[me.cursorY] ~ "\n"
-					var x: int :: me.cursorX
-					var y: int :: me.cursorY
-					var isLastLine: bool :: y = ^me.src.src - 1
-					do me.delLine(x, y, true)
-					do me.insLine(x, y - 1, src, true)
-					if(isLastLine)
-						do me.bs(0, y + 1, 1, true)
+				if(me.areaSel())
+					if(lib@min(me.areaY, me.cursorY) <> 0)
+						do me.undoRecordBegin()
+						var x1: int :: me.areaX
+						var y1: int :: me.areaY
+						var x2: int :: me.cursorX
+						var y2: int :: me.cursorY
+						var yDel: int :: lib@min(y1, y2) - 1
+						var yIns: int :: lib@max(y1, y2)
+						do me.ins(^me.src.src[yIns], yIns, "\n" ~ me.src.src[yDel], true)
+						do me.del(0, yDel, ^me.src.src[yDel] + 1, true)
+						do me.areaX :: x1
+						do me.areaY :: y1 - 1
+						do me.cursorX :: x2
+						do me.cursorY :: y2 - 1
+						do me.interpret1SetDirty(me.cursorY, true, false)
+						do me.undoRecordEnd()
 					end if
-					do me.cursorX :: x
-					do me.cursorY :: y - 1
-					do me.interpret1SetDirty(me.cursorY, true, false)
-					do me.undoRecordEnd()
+				else
+					if(me.cursorY <> 0)
+						do me.undoRecordBegin()
+						var x: int :: me.cursorX
+						var y: int :: me.cursorY
+						var yDel: int :: y - 1
+						var yIns: int :: y
+						do me.ins(^me.src.src[yIns], yIns, "\n" ~ me.src.src[yDel], true)
+						do me.del(0, yDel, ^me.src.src[yDel] + 1, true)
+						do me.cursorX :: x
+						do me.cursorY :: y - 1
+						do me.interpret1SetDirty(me.cursorY, true, false)
+						do me.undoRecordEnd()
+					end if
 				end if
 			else
 				do me.setArea(shiftCtrl)
@@ -479,21 +496,38 @@ end func
 				do me.scrollPageY(1)
 				do \form@paintDrawEditor(false)
 			elif(wnd@key(%alt))
-				if(me.cursorY <> ^me.src.src - 1 & !me.areaSel())
-					do me.undoRecordBegin()
-					var x: int :: me.cursorX
-					var y: int :: me.cursorY
-					var isLastLine: bool :: y + 1 = ^me.src.src - 1
-					var src: []char :: me.src.src[y + 1] ~ "\n"
-					do me.delLine(x, y + 1, true)
-					do me.insLine(x, y, src, true)
-					if(isLastLine)
-						do me.bs(0, y + 2, 1, true)
+				if(me.areaSel())
+					if(lib@max(me.areaY, me.cursorY) <> ^me.src.src - 1)
+						do me.undoRecordBegin()
+						var x1: int :: me.areaX
+						var y1: int :: me.areaY
+						var x2: int :: me.cursorX
+						var y2: int :: me.cursorY
+						var yIns: int :: lib@min(y1, y2)
+						var yDel: int :: lib@max(y1, y2) + 1
+						do me.ins(0, yIns, me.src.src[yDel] ~ "\n", true)
+						do me.del(^me.src.src[yDel], yDel, ^me.src.src[yDel + 1] + 1, true)
+						do me.areaX :: x1
+						do me.areaY :: y1 + 1
+						do me.cursorX :: x2
+						do me.cursorY :: y2 + 1
+						do me.interpret1SetDirty(me.cursorY, true, false)
+						do me.undoRecordEnd()
 					end if
-					do me.cursorX :: x
-					do me.cursorY :: y + 1
-					do me.interpret1SetDirty(me.cursorY, true, false)
-					do me.undoRecordEnd()
+				else
+					if(me.cursorY <> ^me.src.src - 1)
+						do me.undoRecordBegin()
+						var x: int :: me.cursorX
+						var y: int :: me.cursorY
+						var yIns: int :: y
+						var yDel: int :: y + 1
+						do me.ins(0, yIns, me.src.src[yDel] ~ "\n", true)
+						do me.del(^me.src.src[yDel], yDel, ^me.src.src[yDel + 1] + 1, true)
+						do me.cursorX :: x
+						do me.cursorY :: y + 1
+						do me.interpret1SetDirty(me.cursorY, true, false)
+						do me.undoRecordEnd()
+					end if
 				end if
 			else
 				do me.setArea(shiftCtrl)
@@ -1673,11 +1707,8 @@ end func
 			do redo.y :: y
 			do redo.str :: str
 		end if
-		do me.cursorX :: x
-		do me.cursorY :: y
-		var absoluteX: int :: me.getAbsoluteX()
 		do me.ins(0, y, str, false)
-		do me.setAbsoluteX(absoluteX)
+		do me.cursorX :: x
 		if(recordUndo)
 			var undo: UndoSrcDelLine :: #UndoSrcDelLine
 			do undo.doc :: me


### PR DESCRIPTION
#174 で範囲選択時の動作に対応していなかったのを対応しました。

( #174 では、「選択中の複数行を削除して挿入する」というやや複雑な処理を考えてしまって手を付けていなかったのですが、
「選択範囲の上の行を下に移動したり、その逆の処理をする」という処理で実現できることに気づいたので実装しました。
 範囲選択していない場合の処理もその方針で書き直しました。シンプルな実装になったと思います。)