### PR TITLE
【Kuinエディタ】クラス定義時、初回だけ Shiftキー＋セミコロンキー（'+'の入力）を2回押さないと'+'が入力されない現象の修正

### DIFF
--- a/src/kuin_editor/doc_src.kn
+++ b/src/kuin_editor/doc_src.kn
@@ -1213,6 +1213,7 @@ end func
 		else
 			do line :: -1 - line
 			do me.ins(^me.src.src[line], line, ##str, true)
+			do me.forceToInterpret1 :: false
 		end if
 	end func
 	


### PR DESCRIPTION
#140 「クラス定義時、初回だけ Shiftキー＋セミコロンキー（'+'の入力）を2回押さないと'+'が入力されない現象」の修正です。

## #140 の問題が発生する流れの概要
`class C()` と入力して改行すると `end class` の自動補完が行われます。
この際、`replaceForAuxiliary` メソッド内で以下の `ins` メソッドが呼ばれます。 
https://github.com/kuina/Kuin/blob/54e5e9a4796ba628bb1c32b0dc841c7c1acdc2a6/src/kuin_editor/doc_src.kn#L1215

この時点で、str = "\nend class" であるため、 `ins` メソッド内で `me.forceToInterpret1 :: true` になります。

https://github.com/kuina/Kuin/blob/54e5e9a4796ba628bb1c32b0dc841c7c1acdc2a6/src/kuin_editor/doc_src.kn#L1693

この後、キーボードから「+」を入力すると、 `keyChar` メソッド内で `interpret1SetDirty` メソッドが呼ばれます。

https://github.com/kuina/Kuin/blob/54e5e9a4796ba628bb1c32b0dc841c7c1acdc2a6/src/kuin_editor/doc_src.kn#L577

`me.forceToInterpret1 :: true` の状態で `interpret1SetDirty` が呼ばれることで、「+」が消えます。
(もう一度「+」を入力すると、そのときには `me.forceToInterpret1 :: false` になっているため、消えずに残ります。)

class に限らず、すべてのブロックで同様の動作になります。

## 修正内容について
https://github.com/kuina/Kuin/blob/54e5e9a4796ba628bb1c32b0dc841c7c1acdc2a6/src/kuin_editor/doc_src.kn#L1213-L1215
の箇所を通るのは「end ～」が自動補完される場合に限定され、この直前では `me.forceToInterpret1 :: false` となっていると考えられるため、この `ins` の直後に `do me.forceToInterpret1 :: false` を追加しました。