### PR TITLE
【Kuinエディタ】アンドゥ/リドゥ後のシンタックスハイライト

### DIFF
--- a/src/kuin_editor/doc_src.kn
+++ b/src/kuin_editor/doc_src.kn
@@ -748,6 +748,7 @@ end func
 				do me.cursorY :: undo3.cursorY
 				do me.areaX :: undo3.areaX
 				do me.areaY :: undo3.areaY
+				do me.interpret1SetDirty(me.cursorY, true, false)
 			end block
 		else
 			assert false


### PR DESCRIPTION
* 例えば「do」を入力してアンドゥすると、dが青色のままで、リドゥすると「o」の部分が灰色になっていました。
* 「do」を入力してアンドゥすると、dが水色に戻って、リドゥすると「do」が青色に戻るようにしました。