### PR TITLE
コンパイルエラーメッセージ内の位置情報の修正

### DIFF
--- a/src/compiler/parse.kn
+++ b/src/compiler/parse.kn
@@ -2044,9 +2044,9 @@ func parseExprCall(): \ast@AstExpr
 end func
 
 func parseExprValue(): \ast@AstExpr
+	var c: char :: @readChar()
 	var row: int :: @row
 	var col: int :: @col
-	var c: char :: @readChar()
 	var pos: \pos@Pos :: \pos@make(@srcName, row, col)
 	switch(c)
 	case '"'


### PR DESCRIPTION
```
func main()
	do x :: y + z
end func
```
例えば上記コードをコンパイルして表示されるエラーメッセージ内の位置情報が不自然でした。これを修正しました。

## 変更前
```
0x00020006: 識別子「x」の定義が見つかりません。名前を間違えている可能性があります。 (\main: 2, 4)
0x00020006: 識別子「y」の定義が見つかりません。名前を間違えている可能性があります。 (\main: 2, 8)
0x00020006: 識別子「z」の定義が見つかりません。名前を間違えている可能性があります。 (\main: 2, 12)
```
Kuinエディタで見たときに、 ​`do` `::` ` `(yの直後の半角スペース) が強調されます。

## 変更後
```
0x00020006: 識別子「x」の定義が見つかりません。名前を間違えている可能性があります。 (\main: 2, 5)
0x00020006: 識別子「y」の定義が見つかりません。名前を間違えている可能性があります。 (\main: 2, 10)
0x00020006: 識別子「z」の定義が見つかりません。名前を間違えている可能性があります。 (\main: 2, 14)
```
Kuinエディタで見たときに、 `x` `y` `z` が強調されます。