### PR TITLE
skipに不適切なブロック名を指定した場合の「予期せぬエラー」を修正しました。

### DIFF
--- a/src/compiler/analyze.kn
+++ b/src/compiler/analyze.kn
@@ -1822,8 +1822,8 @@ func rebuildSkip(ast: \ast@AstStat, retType: \ast@AstType, parentFunc: \ast@AstF
 	end if
 	do ast.extra :: ast
 	
-	if(ast.refItem =& null | ast.refItem.typeId.and(%statBreakable) <> %statBreakable)
-		do \err@err(%mustSpecifyBlockName, ast.pos, ["skip"])
+	if(ast.refItem =& null | ast.refItem.typeId.and(%statSkipable) <> %statSkipable)
+		do \err@err(%mustSpecifyBlockNameForSkip, ast.pos, null)
 		ret null
 	end if
 	do ast.refItem :: @rebuildStat(ast.refItem $ \ast@AstStat, retType, parentFunc)

--- a/src/compiler/msg.kn
+++ b/src/compiler/msg.kn
@@ -128,6 +128,7 @@
 	excodeMustBeStrConst
 	dictKeyMustBeComparable
 	cannotInstantiateDirectly
+	mustSpecifyBlockNameForSkip
 	
 	_nonErrs :: 0x00030000
 	success
@@ -1008,6 +1009,13 @@ end enum
 			ret "クラス「\{args[0]}」のインスタンスは#演算子で生成できません。"
 		default
 			ret "The class '\{args[0]}' cannot instantiate directly."
+		end switch
+	case %mustSpecifyBlockNameForSkip
+		switch(lang)
+		case "ja"
+			ret "「skip」文には「for」あるいは「while」のブロック名を指定しなければなりません。"
+		default
+			ret "'skip' statements must be given block names for 'for' or 'while'."
 		end switch
 	case %success
 		switch(lang)


### PR DESCRIPTION
下記のコードを「コンパイル＆実行」して「予期せぬエラーです。」となるのを修正しました。
```
func main()
	block a
		skip a
	end block
end func
```

エラー番号を1つ追加しました。
具体的には、 `%mustSpecifyBlockName` を参考に `%mustSpecifyBlockNameForSkip` を追加しました。
私には良い方法が思い浮かびませんでしたが、 `%mustSpecifyBlockName` を改造して流用することでエラー番号を追加せずに済ませることも検討の余地がありそうです。