### PR TITLE
skipに不適切なブロック名を指定した場合の「予期せぬエラー」を修正しました。

### DIFF
--- a/src/compiler/analyze.kn
+++ b/src/compiler/analyze.kn
@@ -1822,7 +1822,7 @@ func rebuildSkip(ast: \ast@AstStat, retType: \ast@AstType, parentFunc: \ast@AstF
 	end if
 	do ast.extra :: ast
 	
-	if(ast.refItem =& null | ast.refItem.typeId.and(%statBreakable) <> %statBreakable)
+	if(ast.refItem =& null | ast.refItem.typeId.and(%statSkipable) <> %statSkipable)
 		do \err@err(%mustSpecifyBlockName, ast.pos, ["skip"])
 		ret null
 	end if

--- a/src/compiler/msg.kn
+++ b/src/compiler/msg.kn
@@ -802,9 +802,9 @@ end enum
 	case %mustSpecifyBlockName
 		switch(lang)
 		case "ja"
-			ret "「\{args[0]}」文にはブロック名を指定しなければなりません。"
+			ret "「\{args[0]}」文には「\{args[0]}」用のブロック名を指定しなければなりません。"
 		default
-			ret "'\{args[0]}' statements must be given block names."
+			ret "'\{args[0]}' statements must be given block names for '\{args[0]}'."
 		end switch
 	case %assertCondMustBeBool
 		switch(lang)


### PR DESCRIPTION
下記のコードを「コンパイル＆実行」して「予期せぬエラーです。」となるのを修正しました。
```
func main()
	block a
		skip a
	end block
end func
```

本プルリクでは変更点を少なくしました。
次のように指定可能なブロックの種類を具体的にエラーメッセージ中に表示した方が親切かもしれません。
* `["skip"]` を `["skip", "for, while"]` にする。
* `["break"]` を `["break", "block, for, if, switch, try, while"]` にする。
* エラーメッセージを、 【「`文の名前`」文には次のいずれかのブロック名を指定しなければなりません。 「`指定可能なブロックの種類`」】という具合にする。