### PR TITLE
順列の個数と組み合わせの個数を求める関数を追加

### DIFF
--- a/src/sys/cpp/math.kn
+++ b/src/sys/cpp/math.kn
@@ -443,10 +443,10 @@ func modMulUnsigned(a: bit64, b: bit64, modulus: bit64): bit64
 	ret w
 end func
 
-func permutation(n: int, r: int): int
++func permutation(n: int, r: int): int
 	ret math@factInt(n) / math@factInt(n - r)
 end func
 
-func combination(n: int, r: int): int
++func combination(n: int, r: int): int
 	ret math@factInt(n) / math@factInt(n - r) / math@factInt(r)
 end func

--- a/src/sys/cpp/math.kn
+++ b/src/sys/cpp/math.kn
@@ -444,9 +444,15 @@ func modMulUnsigned(a: bit64, b: bit64, modulus: bit64): bit64
 end func
 
 +func permutation(n: int, r: int): int
+	if(r > n)
+		ret -1
+	end if
 	ret math@factInt(n) / math@factInt(n - r)
 end func
 
 +func combination(n: int, r: int): int
+	if(0 > r | r > n)
+		ret -1
+	end if
 	ret math@factInt(n) / math@factInt(n - r) / math@factInt(r)
 end func

--- a/src/sys/cpp/math.kn
+++ b/src/sys/cpp/math.kn
@@ -442,3 +442,11 @@ func modMulUnsigned(a: bit64, b: bit64, modulus: bit64): bit64
 	end while
 	ret w
 end func
+
+func permutation(n: int, r: int): int
+	ret math@factInt(n) / math@factInt(n - r)
+end func
+
+func combination(n: int, r: int): int
+	ret math@factInt(n) / math@factInt(n - r) / math@factInt(r)
+end func

--- a/src/sys/exe/math.kn
+++ b/src/sys/exe/math.kn
@@ -443,10 +443,10 @@ func modMulUnsigned(a: bit64, b: bit64, modulus: bit64): bit64
 	ret w
 end func
 
-func permutation(n: int, r: int): int
++func permutation(n: int, r: int): int
 	ret math@factInt(n) / math@factInt(n - r)
 end func
 
-func combination(n: int, r: int): int
++func combination(n: int, r: int): int
 	ret math@factInt(n) / math@factInt(n - r) / math@factInt(r)
 end func

--- a/src/sys/exe/math.kn
+++ b/src/sys/exe/math.kn
@@ -444,9 +444,15 @@ func modMulUnsigned(a: bit64, b: bit64, modulus: bit64): bit64
 end func
 
 +func permutation(n: int, r: int): int
+	if(r > n)
+		ret -1
+	end if
 	ret math@factInt(n) / math@factInt(n - r)
 end func
 
 +func combination(n: int, r: int): int
+	if(0 > r | r > n)
+		ret -1
+	end if
 	ret math@factInt(n) / math@factInt(n - r) / math@factInt(r)
 end func

--- a/src/sys/exe/math.kn
+++ b/src/sys/exe/math.kn
@@ -442,3 +442,11 @@ func modMulUnsigned(a: bit64, b: bit64, modulus: bit64): bit64
 	end while
 	ret w
 end func
+
+func permutation(n: int, r: int): int
+	ret math@factInt(n) / math@factInt(n - r)
+end func
+
+func combination(n: int, r: int): int
+	ret math@factInt(n) / math@factInt(n - r) / math@factInt(r)
+end func

--- a/src/sys/web/math.kn
+++ b/src/sys/web/math.kn
@@ -443,10 +443,10 @@ func modMulUnsigned(a: bit64, b: bit64, modulus: bit64): bit64
 	ret w
 end func
 
-func permutation(n: int, r: int): int
++func permutation(n: int, r: int): int
 	ret math@factInt(n) / math@factInt(n - r)
 end func
 
-func combination(n: int, r: int): int
++func combination(n: int, r: int): int
 	ret math@factInt(n) / math@factInt(n - r) / math@factInt(r)
 end func

--- a/src/sys/web/math.kn
+++ b/src/sys/web/math.kn
@@ -444,9 +444,15 @@ func modMulUnsigned(a: bit64, b: bit64, modulus: bit64): bit64
 end func
 
 +func permutation(n: int, r: int): int
+	if(r > n)
+		ret -1
+	end if
 	ret math@factInt(n) / math@factInt(n - r)
 end func
 
 +func combination(n: int, r: int): int
+	if(0 > r | r > n)
+		ret -1
+	end if
 	ret math@factInt(n) / math@factInt(n - r) / math@factInt(r)
 end func

--- a/src/sys/web/math.kn
+++ b/src/sys/web/math.kn
@@ -442,3 +442,11 @@ func modMulUnsigned(a: bit64, b: bit64, modulus: bit64): bit64
 	end while
 	ret w
 end func
+
+func permutation(n: int, r: int): int
+	ret math@factInt(n) / math@factInt(n - r)
+end func
+
+func combination(n: int, r: int): int
+	ret math@factInt(n) / math@factInt(n - r) / math@factInt(r)
+end func


### PR DESCRIPTION
順列を取得する関数があったので、順列の個数と組み合わせの個数を求める関数を追加してみました。

${}_n\mathrm{P}_r$=`permutation(n: int, r: int)`
${}_n\mathrm{C}_r$=`combination(n: int, r: int)`
で使えます。

名前が長いので、それぞれpermとcombのように略してもいいかもしれません。