### PR TITLE
スニペットの配置ダイアログでのEnter/Escキーでの配置/キャンセル操作に対応

### DIFF
--- a/src/kuin_editor/snippet.kn
+++ b/src/kuin_editor/snippet.kn
@@ -219,7 +219,10 @@ end func
 		end for
 	end if
 	
+	var oldOnKeyPress: func<(wnd@Key, wnd@ShiftCtrl): bool> :: wnd@getOnKeyPress()
+	do wnd@setOnKeyPress(onKeyPress)
 	do @wndPlace.modal()
+	do wnd@setOnKeyPress(oldOnKeyPress)
 	do @wndPlace :: null
 	do @wndPlaceSnippetCode :: null
 	do @wndPlaceVariables :: null
@@ -242,6 +245,17 @@ end func
 	
 	func btnCancelOnPush(wnd: wnd@WndBase)
 		do @wndPlace.close()
+	end func
+	
+	func onKeyPress(key: wnd@Key, shiftCtrl: wnd@ShiftCtrl): bool
+		if(shiftCtrl = %none)
+			switch(key)
+			case %enter
+				do btnPlaceOnPush(null)
+			case %esc
+				do btnCancelOnPush(null)
+			end switch
+		end if
 	end func
 end func
 


### PR DESCRIPTION
エディタのスニペット配置ダイアログで、ボタンクリックで行う操作をキー操作で行えるようにしました。