### PR TITLE
-e exe 時の float 戻り値不具合を修正

### DIFF
--- a/src/compiler/exe/asm.assemble.kn
+++ b/src/compiler/exe/asm.assemble.kn
@@ -1141,8 +1141,14 @@ func assembleFunc(ast: \ast@AstFunc, entry: bool)
 		do asms.add(@asmNop())
 		do asms.add(scopeGcDec.end_)
 		; Save the return value so that it is not overwritten.
-		if(ast.ret_ <>& null & !\ast@isFloat(ast.ret_))
-			do asms.add(@asmMov(@valReg(8, %si), @valReg(8, %ax)))
+		var tmpRetFloat: \ast@AstArg :: null
+		if(ast.ret_ <>& null)
+			if(\ast@isFloat(ast.ret_))
+				do tmpRetFloat :: @makeTmpVar(8, null)
+				do asms.add(@asmMovsd(@valMem(4, @valReg(8, %sp), null, @refValueAddr(@refLocalVar(tmpRetFloat), false)), @valReg(4, %xmm0)))
+			else
+				do asms.add(@asmMov(@valReg(8, %si), @valReg(8, %ax)))
+			end if
 		end if
 		; Decrement the reference counters of local values.
 		block
@@ -1222,8 +1228,12 @@ func assembleFunc(ast: \ast@AstFunc, entry: bool)
 				do idx :+ 1
 			end while
 		end block
-		if(ast.ret_ <>& null & !\ast@isFloat(ast.ret_))
-			do asms.add(@asmMov(@valReg(8, %ax), @valReg(8, %si)))
+		if(ast.ret_ <>& null)
+			if(\ast@isFloat(ast.ret_))
+				do asms.add(@asmMovsd(@valReg(4, %xmm0), @valMem(4, @valReg(8, %sp), null, @refValueAddr(@refLocalVar(tmpRetFloat), false))))
+			else
+				do asms.add(@asmMov(@valReg(8, %ax), @valReg(8, %si)))
+			end if
 		end if
 		block
 			; Throw the exception again if it has occurred.


### PR DESCRIPTION
Kuin で直接 exe を生成（`-e exe`）した際に、`float` 戻り値を返す関数に関する不具合があるようだったため、修正案を送ります。

## 現象

`cui@inputFloat()` で数値を読むと、`kuincl.exe` で直接 exe を生成した場合、読み取った値が `0` になります。
一方、cpp ファイル生成（`-e cpp`）を経由した場合は正しく動作するようでした。

調査したところ、`cui@inputFloat()` 固有の問題ではなく、`float` の戻り値の保存・復元に関する問題のようでした。

## 最小再現例

```kuin
func main()
	func f(): float
		var x: int :: [1, 2][1]
		ret 1.23
	end func
	
	do cui@print("f: \{f()}\n")
end func
```

## 期待される出力

```text
f: 1.23
```

## 修正前の出力

```text
f: 0
```

## 原因候補

`src/compiler/exe/asm.assemble.kn` の `assembleFunc` 内では、戻り値が後続の後始末処理で壊れないように退避する処理があります。

修正前は、`float` でない戻り値のみが退避対象で、`float` の戻り値の `XMM0` は退避されていないようでした。

そのため、`ret` 後の参照カウント減算・解放処理の過程で `XMM0` が上書きされ、最終的な `float` 戻り値が `0` になっていた可能性があります。

## 修正内容

後始末処理で `float` の戻り値が壊れないよう、`XMM0` の退避・復元処理を追加しました。

## 確認内容

テストケースは追加していませんが、手元で以下の2点が期待通りに動作することを確認しました。

* 最小再現例に記載したコードの出力が `f: 1.23` になる
* `cui@inputFloat()` で `1.23` を読んだ場合も `1.23` になる

網羅的な確認まではできていませんが、見落とし等ありましたらご指摘いただければ幸いです。
